### PR TITLE
Ignore the files generated at the run time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea/
+forms/
+meta.json
+to_add.txt


### PR DESCRIPTION
It's convenient for local development when the source directory is symlinked into the addons directory.