### PR TITLE
Add batch input mode for simplified Chinese

### DIFF
--- a/designer/dict_ui.ui
+++ b/designer/dict_ui.ui
@@ -290,6 +290,12 @@
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
       <widget class="QLineEdit" name="Query">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="font">
         <font>
          <family>SimHei</family>

--- a/designer/dict_ui.ui
+++ b/designer/dict_ui.ui
@@ -19,297 +19,198 @@
   <property name="windowTitle">
    <string>CC-CEDICT for Anki</string>
   </property>
-  <property name="windowIcon">
-   <iconset resource="icons.qrc">
-    <normaloff>:/icon/icons/icon.png</normaloff>:/icon/icons/icon.png</iconset>
-  </property>
-  <layout class="QGridLayout" name="gridLayout_4">
-   <item row="0" column="1">
-    <widget class="QScrollArea" name="scrollArea">
-     <property name="widgetResizable">
-      <bool>true</bool>
-     </property>
-     <widget class="QWidget" name="scrollAreaWidgetContents">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>518</width>
-        <height>182</height>
-       </rect>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>641</width>
+     <height>371</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLineEdit" name="Query">
+      <property name="font">
+       <font>
+        <family>SimHei</family>
+        <pointsize>8</pointsize>
+       </font>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="Hanzi">
-         <property name="font">
-          <font>
-           <family>SimSun</family>
-           <pointsize>20</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>漢字
-汉字</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="Pinyin">
-         <property name="font">
-          <font>
-           <family>Times New Roman</family>
-           <pointsize>12</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Pinyin</string>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="English">
-         <property name="font">
-          <font>
-           <family>Times New Roman</family>
-           <pointsize>12</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>English</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
      </widget>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QGroupBox" name="AddCard">
-     <property name="title">
-      <string>Add Card</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <layout class="QGridLayout" name="gridLayout_2">
-        <item row="0" column="0">
-         <widget class="QLabel" name="Deck_Label">
-          <property name="text">
-           <string>Deck:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLabel" name="Notetype_Label">
-          <property name="text">
-           <string>Notetype:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="Field1_Label">
-          <property name="text">
-           <string>Field 1:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLabel" name="Field2_Label">
-          <property name="text">
-           <string>Field 2:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="2">
-         <widget class="QLabel" name="Field3_Label">
-          <property name="text">
-           <string>Field 3:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="3">
-         <widget class="QLabel" name="Field4_Label">
-          <property name="text">
-           <string>Field 4:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QComboBox" name="Field1">
-          <item>
-           <property name="text">
-            <string>Simplified</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Traditional</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Pinyin</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>English</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="Field2">
-          <item>
-           <property name="text">
-            <string>Traditional</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Simplified</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Pinyin</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>English</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="2">
-         <widget class="QComboBox" name="Field3">
-          <item>
-           <property name="text">
-            <string>Pinyin</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Simplified</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Traditional</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>English</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Nothing</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="3">
-         <widget class="QComboBox" name="Field4">
-          <item>
-           <property name="text">
-            <string>English</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Simplified</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Traditional</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Pinyin</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Nothing</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="4" column="3">
-         <widget class="QPushButton" name="About">
-          <property name="text">
-           <string>About</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="2">
-         <widget class="QComboBox" name="Deck"/>
-        </item>
-        <item row="1" column="2" colspan="2">
-         <widget class="QComboBox" name="Notetype"/>
-        </item>
-        <item row="4" column="0" colspan="3">
-         <widget class="QPushButton" name="Add">
-          <property name="text">
-           <string>Add card(s)</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
+    </item>
+    <item row="2" column="0" colspan="5">
+     <widget class="QListWidget" name="Results">
+      <property name="font">
+       <font>
+        <family>SimHei</family>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="3">
+     <widget class="QComboBox" name="Input_Type">
+      <item>
+       <property name="text">
+        <string>Simplified</string>
+       </property>
       </item>
-      <item row="1" column="0">
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
+      <item>
+       <property name="text">
+        <string>Traditional</string>
+       </property>
       </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="0" rowspan="2">
-    <layout class="QGridLayout" name="gridLayout">
+      <item>
+       <property name="text">
+        <string>English</string>
+       </property>
+      </item>
+     </widget>
+    </item>
+    <item row="0" column="2">
+     <widget class="QPushButton" name="SearchButton">
+      <property name="font">
+       <font>
+        <pointsize>8</pointsize>
+       </font>
+      </property>
+      <property name="text">
+       <string>Search</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="4">
+     <widget class="QCheckBox" name="checkBox">
+      <property name="text">
+       <string>Show only exact matches</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QGroupBox" name="AddCard">
+   <property name="geometry">
+    <rect>
+     <x>660</x>
+     <y>210</y>
+     <width>411</width>
+     <height>172</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Add Card</string>
+   </property>
+   <widget class="QWidget" name="">
+    <property name="geometry">
+     <rect>
+      <x>13</x>
+      <y>29</y>
+      <width>391</width>
+      <height>134</height>
+     </rect>
+    </property>
+    <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
-      <widget class="QLineEdit" name="Query">
-       <property name="font">
-        <font>
-         <family>SimHei</family>
-         <pointsize>8</pointsize>
-        </font>
+      <widget class="QLabel" name="Deck_Label">
+       <property name="text">
+        <string>Deck:</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="5">
-      <widget class="QListWidget" name="Results">
-       <property name="font">
-        <font>
-         <family>SimHei</family>
-         <pointsize>10</pointsize>
-        </font>
+     <item row="0" column="2">
+      <widget class="QLabel" name="Notetype_Label">
+       <property name="text">
+        <string>Notetype:</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="3">
-      <widget class="QComboBox" name="Input_Type">
+     <item row="2" column="0">
+      <widget class="QLabel" name="Field1_Label">
+       <property name="text">
+        <string>Field 1:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="Field2_Label">
+       <property name="text">
+        <string>Field 2:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="Field3_Label">
+       <property name="text">
+        <string>Field 3:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QLabel" name="Field4_Label">
+       <property name="text">
+        <string>Field 4:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QComboBox" name="Field1">
+       <item>
+        <property name="text">
+         <string>Simplified</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Traditional</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Pinyin</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>English</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="Field2">
+       <item>
+        <property name="text">
+         <string>Traditional</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Simplified</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Pinyin</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>English</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QComboBox" name="Field3">
+       <item>
+        <property name="text">
+         <string>Pinyin</string>
+        </property>
+       </item>
        <item>
         <property name="text">
          <string>Simplified</string>
@@ -325,36 +226,140 @@
          <string>English</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>Nothing</string>
+        </property>
+       </item>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="SearchButton">
-       <property name="font">
-        <font>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
+     <item row="3" column="3">
+      <widget class="QComboBox" name="Field4">
+       <item>
+        <property name="text">
+         <string>English</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Simplified</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Traditional</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Pinyin</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Nothing</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="4" column="3">
+      <widget class="QPushButton" name="About">
        <property name="text">
-        <string>Search</string>
+        <string>About</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="4">
-      <widget class="QCheckBox" name="checkBox">
+     <item row="1" column="0" colspan="2">
+      <widget class="QComboBox" name="Deck"/>
+     </item>
+     <item row="1" column="2" colspan="2">
+      <widget class="QComboBox" name="Notetype"/>
+     </item>
+     <item row="4" column="0" colspan="3">
+      <widget class="QPushButton" name="Add">
        <property name="text">
-        <string>Show only exact matches</string>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
+        <string>Add card</string>
        </property>
       </widget>
      </item>
     </layout>
-   </item>
-  </layout>
+   </widget>
+  </widget>
+  <widget class="QScrollArea" name="scrollArea">
+   <property name="geometry">
+    <rect>
+     <x>660</x>
+     <y>10</y>
+     <width>411</width>
+     <height>191</height>
+    </rect>
+   </property>
+   <property name="widgetResizable">
+    <bool>true</bool>
+   </property>
+   <widget class="QWidget" name="scrollAreaWidgetContents">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>409</width>
+      <height>189</height>
+     </rect>
+    </property>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="Hanzi">
+       <property name="font">
+        <font>
+         <family>SimSun</family>
+         <pointsize>20</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>漢字
+汉字</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="Pinyin">
+       <property name="font">
+        <font>
+         <family>Times New Roman</family>
+         <pointsize>12</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Pinyin</string>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="English">
+       <property name="font">
+        <font>
+         <family>Times New Roman</family>
+         <pointsize>12</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>English</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
  </widget>
- <resources>
-  <include location="icons.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/designer/dict_ui.ui
+++ b/designer/dict_ui.ui
@@ -19,347 +19,342 @@
   <property name="windowTitle">
    <string>CC-CEDICT for Anki</string>
   </property>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>641</width>
-     <height>371</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
-     <widget class="QLineEdit" name="Query">
-      <property name="font">
-       <font>
-        <family>SimHei</family>
-        <pointsize>8</pointsize>
-       </font>
+  <property name="windowIcon">
+   <iconset resource="icons.qrc">
+    <normaloff>:/icon/icons/icon.png</normaloff>:/icon/icons/icon.png</iconset>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="0" column="1">
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>518</width>
+        <height>182</height>
+       </rect>
       </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="Hanzi">
+         <property name="font">
+          <font>
+           <family>SimSun</family>
+           <pointsize>20</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>漢字
+汉字</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="Pinyin">
+         <property name="font">
+          <font>
+           <family>Times New Roman</family>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>Pinyin</string>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="English">
+         <property name="font">
+          <font>
+           <family>Times New Roman</family>
+           <pointsize>12</pointsize>
+          </font>
+         </property>
+         <property name="text">
+          <string>English</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
-    </item>
-    <item row="2" column="0" colspan="5">
-     <widget class="QListWidget" name="Results">
-      <property name="font">
-       <font>
-        <family>SimHei</family>
-        <pointsize>10</pointsize>
-       </font>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="3">
-     <widget class="QComboBox" name="Input_Type">
-      <item>
-       <property name="text">
-        <string>Simplified</string>
-       </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QGroupBox" name="AddCard">
+     <property name="title">
+      <string>Add Card</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="Deck_Label">
+          <property name="text">
+           <string>Deck:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QLabel" name="Notetype_Label">
+          <property name="text">
+           <string>Notetype:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="Field1_Label">
+          <property name="text">
+           <string>Field 1:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="Field2_Label">
+          <property name="text">
+           <string>Field 2:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QLabel" name="Field3_Label">
+          <property name="text">
+           <string>Field 3:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QLabel" name="Field4_Label">
+          <property name="text">
+           <string>Field 4:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QComboBox" name="Field1">
+          <item>
+           <property name="text">
+            <string>Simplified</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Traditional</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Pinyin</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>English</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QComboBox" name="Field2">
+          <item>
+           <property name="text">
+            <string>Traditional</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simplified</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Pinyin</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>English</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QComboBox" name="Field3">
+          <item>
+           <property name="text">
+            <string>Pinyin</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simplified</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Traditional</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>English</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Nothing</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QComboBox" name="Field4">
+          <item>
+           <property name="text">
+            <string>English</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simplified</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Traditional</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Pinyin</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Nothing</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="4" column="3">
+         <widget class="QPushButton" name="About">
+          <property name="text">
+           <string>About</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <widget class="QComboBox" name="Deck"/>
+        </item>
+        <item row="1" column="2" colspan="2">
+         <widget class="QComboBox" name="Notetype"/>
+        </item>
+        <item row="4" column="0" colspan="3">
+         <widget class="QPushButton" name="Add">
+          <property name="text">
+           <string>Add card(s)</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item>
-       <property name="text">
-        <string>Traditional</string>
-       </property>
+      <item row="1" column="0">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
       </item>
-      <item>
-       <property name="text">
-        <string>English</string>
-       </property>
-      </item>
-     </widget>
-    </item>
-    <item row="0" column="2">
-     <widget class="QPushButton" name="SearchButton">
-      <property name="font">
-       <font>
-        <pointsize>8</pointsize>
-       </font>
-      </property>
-      <property name="text">
-       <string>Search</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="4">
-     <widget class="QCheckBox" name="checkBox">
-      <property name="text">
-       <string>Show only exact matches</string>
-      </property>
-      <property name="checked">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="QGroupBox" name="AddCard">
-   <property name="geometry">
-    <rect>
-     <x>660</x>
-     <y>210</y>
-     <width>411</width>
-     <height>172</height>
-    </rect>
-   </property>
-   <property name="title">
-    <string>Add Card</string>
-   </property>
-   <widget class="QWidget" name="">
-    <property name="geometry">
-     <rect>
-      <x>13</x>
-      <y>29</y>
-      <width>391</width>
-      <height>134</height>
-     </rect>
-    </property>
-    <layout class="QGridLayout" name="gridLayout_2">
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0" rowspan="2">
+    <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
-      <widget class="QLabel" name="Deck_Label">
-       <property name="text">
-        <string>Deck:</string>
+      <widget class="QLineEdit" name="Query">
+       <property name="font">
+        <font>
+         <family>SimHei</family>
+         <pointsize>8</pointsize>
+        </font>
        </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="5">
+      <widget class="QListWidget" name="Results">
+       <property name="font">
+        <font>
+         <family>SimHei</family>
+         <pointsize>10</pointsize>
+        </font>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QComboBox" name="Input_Type">
+       <item>
+        <property name="text">
+         <string>Simplified</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Traditional</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>English</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="0" column="2">
-      <widget class="QLabel" name="Notetype_Label">
+      <widget class="QPushButton" name="SearchButton">
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
+       </property>
        <property name="text">
-        <string>Notetype:</string>
+        <string>Search</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="Field1_Label">
+     <item row="0" column="4">
+      <widget class="QCheckBox" name="checkBox">
        <property name="text">
-        <string>Field 1:</string>
+        <string>Show only exact matches</string>
        </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="Field2_Label">
-       <property name="text">
-        <string>Field 2:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QLabel" name="Field3_Label">
-       <property name="text">
-        <string>Field 3:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QLabel" name="Field4_Label">
-       <property name="text">
-        <string>Field 4:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QComboBox" name="Field1">
-       <item>
-        <property name="text">
-         <string>Simplified</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Traditional</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Pinyin</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>English</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QComboBox" name="Field2">
-       <item>
-        <property name="text">
-         <string>Traditional</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Simplified</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Pinyin</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>English</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="Field3">
-       <item>
-        <property name="text">
-         <string>Pinyin</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Simplified</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Traditional</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>English</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Nothing</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="3">
-      <widget class="QComboBox" name="Field4">
-       <item>
-        <property name="text">
-         <string>English</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Simplified</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Traditional</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Pinyin</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Nothing</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="4" column="3">
-      <widget class="QPushButton" name="About">
-       <property name="text">
-        <string>About</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="2">
-      <widget class="QComboBox" name="Deck"/>
-     </item>
-     <item row="1" column="2" colspan="2">
-      <widget class="QComboBox" name="Notetype"/>
-     </item>
-     <item row="4" column="0" colspan="3">
-      <widget class="QPushButton" name="Add">
-       <property name="text">
-        <string>Add card</string>
+       <property name="checked">
+        <bool>false</bool>
        </property>
       </widget>
      </item>
     </layout>
-   </widget>
-  </widget>
-  <widget class="QScrollArea" name="scrollArea">
-   <property name="geometry">
-    <rect>
-     <x>660</x>
-     <y>10</y>
-     <width>411</width>
-     <height>191</height>
-    </rect>
-   </property>
-   <property name="widgetResizable">
-    <bool>true</bool>
-   </property>
-   <widget class="QWidget" name="scrollAreaWidgetContents">
-    <property name="geometry">
-     <rect>
-      <x>0</x>
-      <y>0</y>
-      <width>409</width>
-      <height>189</height>
-     </rect>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QLabel" name="Hanzi">
-       <property name="font">
-        <font>
-         <family>SimSun</family>
-         <pointsize>20</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>漢字
-汉字</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="Pinyin">
-       <property name="font">
-        <font>
-         <family>Times New Roman</family>
-         <pointsize>12</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>Pinyin</string>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="English">
-       <property name="font">
-        <font>
-         <family>Times New Roman</family>
-         <pointsize>12</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>English</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </widget>
-  </widget>
+   </item>
+  </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="icons.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/main.py
+++ b/main.py
@@ -93,10 +93,10 @@ class start_main(QDialog):
 			self.dialog.Results.addItem(line)
 
 	def search_word(self, word):
-		debug("search word: {}".format(word))
+		# debug("search word: {}".format(word))
 		c.execute('SELECT * FROM dictionary WHERE hanzi_simp=?', (word,))
 		row = c.fetchone()
-		debug("row is {}".format(str(row)))
+		# debug("row is {}".format(str(row)))
 		if row:
 			traditional = row[0]
 			simplified = row[1]
@@ -110,7 +110,6 @@ class start_main(QDialog):
 			self.skipped.append(word)
 
 	def search(self):
-		debug('Ray Yang search called')
 		self.skipped = []
 		self.inputs = []
 		self.duplicate = []
@@ -118,7 +117,7 @@ class start_main(QDialog):
 		query = self.dialog.Query.text()
 		# note that this is the Chinese "，" character which is different from "," in English.
 		words = [w.strip() for w in query.split("，")]
-		debug("words: {}, len: {}".format(str(words), len(words)))
+		# debug("words: {}, len: {}".format(str(words), len(words)))
 		if len(words) > 1:
 			self.batch_mode_search(words)
 			return

--- a/main.py
+++ b/main.py
@@ -4,7 +4,8 @@ from os.path import dirname, join, realpath
 
 from aqt import mw
 from aqt.qt import *
-from aqt.utils import showInfo
+from aqt.utils import showInfo, tooltip
+
 
 from .forms import dict_ui
 from .import_file import importfile
@@ -15,6 +16,10 @@ conn = connect(db_path)
 c = conn.cursor()
 
 
+def debug(s):
+	sys.stdout.write(s + "\n")
+
+
 class start_main(QDialog):
 
 	def __init__(self, parent=None):
@@ -23,6 +28,9 @@ class start_main(QDialog):
 		self.dialog = dict_ui.Ui_Dialog()
 		self.dialog.setupUi(self)
 		self.setupUI()
+		self.inputs = []
+		self.skipped = []
+		self.duplicate = []
 
 	def setupUI(self):
 
@@ -77,11 +85,44 @@ class start_main(QDialog):
 			line = str(simplified + "\t" + traditional + "\t" + p + "\t" + english)
 			self.dialog.Results.addItem(line)
 
+	def batch_mode_search(self, words):
+		for w in words:
+			self.search_word(w)
+		if self.skipped:
+			line = "Can't find {} words: {}".format(len(self.skipped), ",".join(self.skipped))
+			self.dialog.Results.addItem(line)
+
+	def search_word(self, word):
+		debug("search word: {}".format(word))
+		c.execute('SELECT * FROM dictionary WHERE hanzi_simp=?', (word,))
+		row = c.fetchone()
+		debug("row is {}".format(str(row)))
+		if row:
+			traditional = row[0]
+			simplified = row[1]
+			pin_ying = row[2]
+			english = row[3]
+			line = str(simplified + "\t" + traditional + "\t" + pin_ying + "\t" + english)
+			self.dialog.Results.addItem(line)
+			self.inputs.append(row)
+		else:
+			self.skipped.append(word)
+
 	def search(self):
-		line_list = []
+		debug('Ray Yang search called')
+		self.skipped = []
+		self.inputs = []
+		self.duplicate = []
 		self.dialog.Results.clear()
 		query = self.dialog.Query.text()
+		# note that this is the Chinese "，" character which is different from "," in English.
+		words = [w.strip() for w in query.split("，")]
+		debug("words: {}, len: {}".format(str(words), len(words)))
+		if len(words) > 1:
+			self.batch_mode_search(words)
+			return
 
+		line_list = []
 		if self.dialog.Input_Type.currentText() == "Traditional":
 			#exact match
 			c.execute('SELECT * FROM dictionary WHERE hanzi_trad=?', (query,))
@@ -196,7 +237,44 @@ class start_main(QDialog):
 		self.dialog.Pinyin.adjustSize()
 		self.dialog.Hanzi.adjustSize()
 
+	def add_note(self, row):
+		col = mw.col
+		deck_name = self.dialog.Deck.currentText()
+		did = col.decks.id_for_name(deck_name)
+		note_type_name = self.dialog.Notetype.currentText()
+		m = col.models.byName(note_type_name)
+		col.models.setCurrent(m)
+		n = col.newNote()
+		traditional = row[0]
+		simplified = row[1]
+		pin_ying = row[2]
+		english = row[3]
+
+		n['Pinyin'] = pin_ying
+		simplified_field_name = "Simplified"
+		n[simplified_field_name] = simplified
+		n['English'] = english
+		n['Traditional'] = traditional
+		node_ids = col.find_notes("{}:{}".format(simplified_field_name, simplified))
+		if node_ids:
+			showInfo("The note with the question {} already exists".format(simplified))
+			self.duplicate.append(simplified)
+		else:
+			col.add_note(n, did)
+
+
+	def add_multiple_notes(self):
+		for row in self.inputs:
+			self.add_note(row)
+		added_count = len(self.inputs) - len(self.duplicate)
+		tooltip("Added {} notes, skipped: {}, duplicate: {}".format(
+			added_count, len(self.skipped), len(self.duplicate)))
+
 	def Add_Card(self):
+		if self.inputs:
+			self.add_multiple_notes()
+			return
+
 		to_add =  open(join(dirname(realpath(__file__)), 'to_add.txt'), "w", encoding="utf-8")
 		Hanzi = self.dialog.Hanzi.text()
 		Hanzi = Hanzi.split("\n")

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ class start_main(QDialog):
 			self.search_word(w)
 		if self.skipped:
 			line = "Can't find {} words: {}".format(len(self.skipped), ",".join(self.skipped))
-			self.dialog.Results.addItem(line)
+			showInfo(line)
 
 	def search_word(self, word):
 		# debug("search word: {}".format(word))

--- a/main.py
+++ b/main.py
@@ -31,6 +31,7 @@ class start_main(QDialog):
 		self.inputs = []
 		self.skipped = []
 		self.duplicate = []
+		self.batch_search_mode = False
 
 	def setupUI(self):
 
@@ -86,6 +87,7 @@ class start_main(QDialog):
 			self.dialog.Results.addItem(line)
 
 	def batch_mode_search(self, words):
+		self.batch_search_mode = True
 		for w in words:
 			self.search_word(w)
 		if self.skipped:
@@ -113,6 +115,7 @@ class start_main(QDialog):
 		self.skipped = []
 		self.inputs = []
 		self.duplicate = []
+		self.batch_search_mode = False
 		self.dialog.Results.clear()
 		query = self.dialog.Query.text()
 		# note that this is the Chinese "，" character which is different from "," in English.
@@ -270,8 +273,9 @@ class start_main(QDialog):
 			added_count, len(self.skipped), len(self.duplicate)))
 
 	def Add_Card(self):
-		if self.inputs:
-			self.add_multiple_notes()
+		if self.batch_search_mode:
+			if self.inputs:
+				self.add_multiple_notes()
 			return
 
 		to_add =  open(join(dirname(realpath(__file__)), 'to_add.txt'), "w", encoding="utf-8")

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from os.path import dirname, join, realpath
 from aqt import mw
 from aqt.qt import *
 from aqt.utils import showInfo, tooltip
+from aqt.main import ResetReason
 
 
 from .forms import dict_ui
@@ -268,6 +269,9 @@ class start_main(QDialog):
 		added_count = len(self.inputs) - len(self.duplicate)
 		tooltip("Added {} notes, skipped: {}, duplicate: {}".format(
 			added_count, len(self.skipped), len(self.duplicate)))
+		if added_count > 0:
+			# Signal queue needs to be rebuilt when edits are finished or by user.
+			mw.requireReset(reason=ResetReason.AddCardsAddNote)
 
 	def Add_Card(self):
 		if self.inputs:

--- a/main.py
+++ b/main.py
@@ -101,7 +101,8 @@ class start_main(QDialog):
 			traditional = row[0]
 			simplified = row[1]
 			pin_ying = row[2]
-			english = row[3]
+			# the English part contains a new line.
+			english = row[3].rstrip("\n")
 			line = str(simplified + "\t" + traditional + "\t" + pin_ying + "\t" + english)
 			self.dialog.Results.addItem(line)
 			self.inputs.append(row)
@@ -261,7 +262,6 @@ class start_main(QDialog):
 			self.duplicate.append(simplified)
 		else:
 			col.add_note(n, did)
-
 
 	def add_multiple_notes(self):
 		for row in self.inputs:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ from os.path import dirname, join, realpath
 from aqt import mw
 from aqt.qt import *
 from aqt.utils import showInfo, tooltip
-from aqt.main import ResetReason
 
 
 from .forms import dict_ui
@@ -269,9 +268,6 @@ class start_main(QDialog):
 		added_count = len(self.inputs) - len(self.duplicate)
 		tooltip("Added {} notes, skipped: {}, duplicate: {}".format(
 			added_count, len(self.skipped), len(self.duplicate)))
-		if added_count > 0:
-			# Signal queue needs to be rebuilt when edits are finished or by user.
-			mw.requireReset(reason=ResetReason.AddCardsAddNote)
 
 	def Add_Card(self):
 		if self.inputs:


### PR DESCRIPTION
Add batch input mode #3 

The batch input mode is triggered by typing phrases separated by the Chinese "，" character. Note NOT the English "," character in the search box.

The exact match mode will be used to search these phrases and display all of the results in the result box below.

When the "add cards" button is clicked, all of these entries will be added except the ones that are duplicates.

Currently, only simplified Chinese is supported.