### PR TITLE
Fix note type not matching the selected type error

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,7 +235,9 @@ class start_main(QDialog):
 		note_type_name = self.dialog.Notetype.currentText()
 		m = col.models.byName(note_type_name)
 		col.models.setCurrent(m)
-		n = col.newNote()
+		# Since we don't set the model for the selected desk, set the forDeck parameter to false
+		# to make sure the current global model is used for the new note.
+		n = col.newNote(forDeck=False)
 		simplified = row[0]
 		traditional = row[1]
 		pinyin = row[2]


### PR DESCRIPTION
Problem:
The new card doesn't always use the selected note type

Issue:
The code will set the global note type but it doesn't set the note type for the current deck. When creating a new note, the note type for the current deck is used.

Fix:
When creating a new note, use the current global note type.